### PR TITLE
Update compatibility with Magento 2.4.4 and PHP 8.1

### DIFF
--- a/Model/Client/Embed.php
+++ b/Model/Client/Embed.php
@@ -29,7 +29,15 @@ class Embed extends Base
             );
             $token = $this->getGr4vyConfig()->getEmbedToken($embed_params);
             $this->gr4vyLogger->logMixed($embed_params);
-            return $token->toString();
+
+            if (is_object($token)) {
+                $token_str = $token->toString();
+            }
+            else {
+                $token_str = (string) $token;
+            }
+
+            return $token_str;
         }
         catch (\Exception $e) {
             $this->gr4vyLogger->logException($e);

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.2.0",
         "ext-hash": "*",
         "ext-json": "*",
         "magento/framework": ">=101 <104",
@@ -25,7 +24,7 @@
         "magento/module-config": ">=100 <103",
         "magento/module-payment": "100.*",
         "psr/log": "^1.1",
-        "gr4vy/gr4vy-php": ">=0.12.0"
+        "gr4vy/gr4vy-php": ">=0.13.0"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "gr4vy/magento",
     "description": "Magento 2 Payment module from Gr4vy",
     "type": "magento2-module",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/view/frontend/web/js/view/payment/method-renderer/gr4vy-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gr4vy-method.js
@@ -145,6 +145,10 @@ define(
             },
             calculateShippingFee: function () {
                 var selected_shipping_method = window.checkoutConfig.selectedShippingMethod;
+                if (selected_shipping_method === null) {
+                    // 2.4.4 compatibility fix
+                    selected_shipping_method = quote.shippingMethod();
+                }
                 if (false) {
                     // TODO when multi shipping address is supported, need to calculate it
                 }


### PR DESCRIPTION
Problem(s) :
- missing PHP 8.1 in composer.json caused installation issue with composer
- gr4vy/gr4vy-php was not compatible with PHP 8.1, caused many issue
- gr4vy/gr4vy-php 0.13.0 returned token as string instead of object,
caused problem with checkout
- gr4vy payment from didn't load on 1st load with magento 2.4.4

Solution(s) :
- remove php condition from composer.json
- increase gr4vy/gr4vy-php version in composer.json
- update Model/Client/Embed.php
- update javascript to handle js issue

Note (optional)