### PR TITLE
Prevent payment form flickering

### DIFF
--- a/Model/Payment/PaymentFormProvider.php
+++ b/Model/Payment/PaymentFormProvider.php
@@ -137,7 +137,8 @@ class PaymentFormProvider implements ConfigProviderInterface
                     'total_amount' => $quote_total,
                     'items' => $this->getCartItemsData($quote, $quote_total),
                     'locale' => $this->getLocaleCode(),
-                    'reload_config_url' => $this->urlBuilder->getUrl('gr4vy/checkout/config')
+                    'reload_config_url' => $this->urlBuilder->getUrl('gr4vy/checkout/config'),
+                    'rendered' => false
                 ]
             ]
         ];

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "gr4vy/magento",
     "description": "Magento 2 Payment module from Gr4vy",
     "type": "magento2-module",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/view/frontend/web/js/action/get-payment-information-mixins.js
+++ b/view/frontend/web/js/action/get-payment-information-mixins.js
@@ -33,9 +33,9 @@ define([
 
             // only reload if gr4vy payment form was rendered before
             if (window.checkoutConfig.payment.gr4vy.rendered) {
+                config.reloadEmbed(new Date().getTime());
                 renderer.remove(gr4vy_entry);
                 renderer.push(gr4vy_entry);
-                config.reloadEmbed(new Date().getTime());
             }
 
             return originalGetPaymentInformation().then(function () {

--- a/view/frontend/web/js/action/get-payment-information-mixins.js
+++ b/view/frontend/web/js/action/get-payment-information-mixins.js
@@ -31,9 +31,12 @@ define([
                 component: 'Gr4vy_Magento/js/view/payment/method-renderer/gr4vy-method'
             };
 
-            renderer.remove(gr4vy_entry);
-            renderer.push(gr4vy_entry);
-            config.reloadEmbed(new Date().getTime());
+            // only reload if gr4vy payment form was rendered before
+            if (window.checkoutConfig.payment.gr4vy.rendered) {
+                renderer.remove(gr4vy_entry);
+                renderer.push(gr4vy_entry);
+                config.reloadEmbed(new Date().getTime());
+            }
 
             return originalGetPaymentInformation().then(function () {
                 loader.stopLoader();

--- a/view/frontend/web/js/action/reload-payment-mixins.js
+++ b/view/frontend/web/js/action/reload-payment-mixins.js
@@ -64,7 +64,8 @@ define([
         last_shipping_country_id = ajax_params['shipping_country_id'];
       }
 
-      if (recalculate_params) {
+      // only reload if params require recalculation and gr4vy payment form was rendered before
+      if (recalculate_params && window.checkoutConfig.payment.gr4vy.rendered) {
           var gr4vy_entry = {
               type: 'gr4vy',
               component: 'Gr4vy_Magento/js/view/payment/method-renderer/gr4vy-method'

--- a/view/frontend/web/js/view/payment/method-renderer/gr4vy-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gr4vy-method.js
@@ -126,6 +126,9 @@ define(
                             placeholder_collection[0].innerHTML += $t('<span class="gr4vy-checkout-notice">Payment method is not available. Please contact us for support</span>');
                             placeholder_collection[0].style.display = 'block';
                         }
+
+                        // mark payment form rendered once after pageload
+                        window.checkoutConfig.payment.gr4vy.rendered = true;
                     });
             },
             /**

--- a/view/frontend/web/js/view/payment/method-renderer/gr4vy-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gr4vy-method.js
@@ -41,7 +41,9 @@ define(
 
                 this._super();
 
-                self.initEmbedPayment();
+                if (window.checkoutConfig.payment.gr4vy.rendered) {
+                    self.initEmbedPayment();
+                }
             },
             initEmbedPayment: function () {
                 var This = this;

--- a/view/frontend/web/template/payment/gr4vy.html
+++ b/view/frontend/web/template/payment/gr4vy.html
@@ -46,6 +46,7 @@
                 </button>-->
             </div>
         </div>
+        <div class="gr4vy-placeholder initializer" style="display: none" data-bind="text: initEmbedPayment()"></div>
     </div>
 </div>
         

--- a/view/frontend/web/template/payment/gr4vy.html
+++ b/view/frontend/web/template/payment/gr4vy.html
@@ -46,7 +46,6 @@
                 </button>-->
             </div>
         </div>
-        <div class="gr4vy-placeholder initializer" style="display: none" data-bind="text: initEmbedPayment()"></div>
     </div>
 </div>
         


### PR DESCRIPTION
Problem(s) :
- Payment form was updated whenever there is get-payment-information event fired , it fired 3 times after page load

Solution(s) :
- Mark rendered status and only re-init embed form if rendered = true

Note (optional)