### PR TITLE
Update gr4vy-method.js

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/gr4vy-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gr4vy-method.js
@@ -125,6 +125,7 @@ define(
                                 onBeforeTransaction: async () => {
                                     This.customPlaceOrder();
                                     console.log('onBeforeTransaction');
+                                    fullScreenLoader.stopLoader();
                                     return {
                                         externalIdentifier: This.incrementId,
                                     }


### PR DESCRIPTION
This fix aims to resolve the issue of the spinning wheel not disappearing if you close the rendered pop-up mid-way during the transaction. Customer has to refresh the checkout page to remove it.