### PR TITLE
fix: Stop additional email being sent for order status update

### DIFF
--- a/Model/Checkout/ProcessResponse.php
+++ b/Model/Checkout/ProcessResponse.php
@@ -216,8 +216,7 @@ class ProcessResponse extends AbstractModel
                 $this->orderHelper->updateOrderHistoryData(
                     $order->getEntityId(),
                     $newOrderStatus,
-                    $msg,
-                    true
+                    $msg
                 );
             }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "gr4vy/magento",
     "description": "Magento 2 Payment module from Gr4vy",
     "type": "magento2-module",
-    "version": "1.1.11",
+    "version": "1.1.12",
     "license": [
         "OSL-3.0",
         "AFL-3.0"


### PR DESCRIPTION
setting the isCustomerNotified to false when there is status update in Gr4vy order to stop triggering the duplicate email.