### PR TITLE
Chore refactoring order logic

### DIFF
--- a/Api/TransactionRepositoryInterface.php
+++ b/Api/TransactionRepositoryInterface.php
@@ -41,6 +41,24 @@ interface TransactionRepositoryInterface
     );
 
     /**
+     * Set Payment Information - Associate transaction payment detail with magento payment object
+     * @param string
+     * @param \Magento\Quote\Api\Data\PaymentInterface $paymentMethod
+     * @param \Gr4vy\Magento\Api\Data\MethodInterface $methodData
+     * @param \Gr4vy\Magento\Api\Data\ServiceInterface $serviceData
+     * @param \Gr4vy\Magento\Api\Data\TransactionInterface $transactionData
+     * @return \Gr4vy\Magento\Api\Data\TransactionInterface
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function saveFailedOrder(
+        $cartId,
+        \Magento\Quote\Api\Data\PaymentInterface $paymentMethod,
+        \Gr4vy\Magento\Api\Data\MethodInterface $methodData,
+        \Gr4vy\Magento\Api\Data\ServiceInterface $serviceData,
+        \Gr4vy\Magento\Api\Data\TransactionInterface $transactionData
+    );
+
+    /**
      * Set Guest Email - store a guest email against the session
      * @param string
      * @param string

--- a/Plugin/OrderEmailPlugin.php
+++ b/Plugin/OrderEmailPlugin.php
@@ -1,0 +1,20 @@
+<?php
+namespace Gr4vy\Magento\Plugin;
+
+class OrderEmailPlugin
+{
+    public function aroundSend(
+        \Magento\Sales\Model\Order\Email\Sender\OrderSender $subject,
+        \Closure $proceed,
+        \Magento\Sales\Model\Order $order,
+        $forceSyncMode = false
+    ) {
+        // Check some condition if needed
+        if ($order->getCustomerEmail() === "fake@email.com") {
+            return false; // Prevent email from being sent
+        }
+
+        // Proceed with the original method if needed
+        return $proceed($order, $forceSyncMode);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "gr4vy/magento",
     "description": "Magento 2 Payment module from Gr4vy",
     "type": "magento2-module",
-    "version": "1.1.13",
+    "version": "1.1.14",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -19,15 +19,18 @@
     </type>
 
     <!--plugins-->
-	<type name="Magento\Quote\Api\CartRepositoryInterface">
-		<plugin name="Gr4vy_Magento_Plugin_Magento_Quote_Api_CartRepositoryInterface" type="Gr4vy\Magento\Plugin\Magento\Quote\Api\CartRepositoryInterface" sortOrder="10" disabled="false"/>
-	</type>
-	<type name="Magento\Quote\Api\PaymentMethodManagementInterface">
-		<plugin name="Gr4vy_Magento_Plugin_Magento_Quote_Api_PaymentMethodManagementInterface" type="Gr4vy\Magento\Plugin\Magento\Quote\Api\PaymentMethodManagementInterface" sortOrder="10" disabled="false"/>
-	</type>
-	<type name="Magento\Customer\Api\AddressRepositoryInterface">
-		<plugin name="Gr4vy_Magento_Plugin_Magento_Customer_Api_AddressRepositoryInterface" type="Gr4vy\Magento\Plugin\Magento\Customer\Api\AddressRepositoryInterface" sortOrder="10" disabled="false"/>
-	</type>
+    <type name="Magento\Sales\Model\Order\Email\Sender\OrderSender">
+        <plugin name="disable_order_email" type="Gr4vy\Magento\Plugin\OrderEmailPlugin" />
+    </type>
+    <type name="Magento\Quote\Api\CartRepositoryInterface">
+        <plugin name="Gr4vy_Magento_Plugin_Magento_Quote_Api_CartRepositoryInterface" type="Gr4vy\Magento\Plugin\Magento\Quote\Api\CartRepositoryInterface" sortOrder="10" disabled="false"/>
+    </type>
+    <type name="Magento\Quote\Api\PaymentMethodManagementInterface">
+        <plugin name="Gr4vy_Magento_Plugin_Magento_Quote_Api_PaymentMethodManagementInterface" type="Gr4vy\Magento\Plugin\Magento\Quote\Api\PaymentMethodManagementInterface" sortOrder="10" disabled="false"/>
+    </type>
+    <type name="Magento\Customer\Api\AddressRepositoryInterface">
+        <plugin name="Gr4vy_Magento_Plugin_Magento_Customer_Api_AddressRepositoryInterface" type="Gr4vy\Magento\Plugin\Magento\Customer\Api\AddressRepositoryInterface" sortOrder="10" disabled="false"/>
+    </type>
 
     <!--logger-->
     <virtualType name="Gr4vy\Magento\Logger\Handler" type="Magento\Framework\Logger\Handler\Base">

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -37,6 +37,13 @@
             <resource ref="anonymous" />
 		</resources>
 	</route>
+	<!--custom save-failed-order-->
+	<route url="/V1/gr4vy-payment/save-failed-order" method="POST">
+		<service class="Gr4vy\Magento\Api\TransactionRepositoryInterface" method="saveFailedOrder"/>
+		<resources>
+			<resource ref="anonymous" />
+		</resources>
+	</route>
 	<route url="/V1/gr4vy-payment/set-guest-email" method="POST">
 		<service class="Gr4vy\Magento\Api\TransactionRepositoryInterface" method="setGuestEmail"/>
 		<resources>


### PR DESCRIPTION
1. Moving the Magento order creation to `onComplete` instead of `onBeforeTransaction`
2. Adding the backend function to create a Magento order for failed, cancelled or declined transactions
3. Magento creates the order in pending state by default and sends an email confirmation so I'm setting the customerEmail to a fake email to stop the real customer getting an email for a failed tx. and then setting the order status to cancelled and setting the customerEmail to the original value.

